### PR TITLE
Fix invalid escape sequence messages

### DIFF
--- a/py_models_parser/grammar.py
+++ b/py_models_parser/grammar.py
@@ -4,7 +4,7 @@ grammar = Grammar(
     r"""
     expr = (class / if_else/ call_result / return / comments / attr_def / emptyline / funct_def)*
     return = "return" (id* ","*)*
-    comments = "\#" (text / list)
+    comments = r"\#" (text / list)
     if_else= ("if" (compare/ id / attr_def) ":")/("elif" (id/attr_def) ":")/("else" ":")
     compare = (call_result / id / args /args_in_brackets  ) operator (call_result/id/args_in_brackets/args)
     operator = "==" / "!=" / ">" / "<" / ">=" / "<="
@@ -25,7 +25,7 @@ grammar = Grammar(
     id          = (((dot_id / text)+ ) *  / dot_id / text) ws?
     dot_id      = (text ".")*text
     intend      = "    " / "\t" / "\n"
-    text        = !"class" ~"['_A-Z 0-9{}_\"\-\/\$<%>\+\-\w*&^%$#!±~`§]*"i
+    text        = !"class" ~r"['_A-Z 0-9{}_\"\-\/\$<%>\+\-\w*&^%$#!±~`§]*"i
     ws          = ~"\\s*"
     emptyline   = ws+
 """


### PR DESCRIPTION
When running 

```python
from omymodels.models.pydantic import types
```

under Python 3.12 I get 

```
<unknown>:1: SyntaxWarning: invalid escape sequence '\#'
<unknown>:1: SyntaxWarning: invalid escape sequence '\-'
```

Based on https://github.com/erikrose/parsimonious/issues/246 this seems to be due to Python getting more aggressive about escape sequences. It also looks like there's a fairly straightforward fix that involves marking the string as a raw string, which I've done in this patch. After making that change the `invalid escape sequence` messages go away.